### PR TITLE
Fix up `abs`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,12 @@ Subsequent commits will then include a new "Unreleased" section in preparation
 for the next release.
 -->
 
+# BioCro C++ Framework VERSION 1.1.2
+
+- Replaced `std::abs` by `fabs` in `quadratic_root.cpp` since `std::abs` is for
+  integer types
+- Removed un-implemented overloaded `abs` defined in `state_map.h`
+
 # BioCro C++ Framework VERSION 1.1.1
 
 - Updated README with links to the new stable location for the BioCro R

--- a/framework_version.h
+++ b/framework_version.h
@@ -5,7 +5,7 @@
 
 namespace biocro_framework
 {
-static const std::string version = "1.1.1";
+static const std::string version = "1.1.2";
 }
 
 #endif

--- a/quadratic_root.cpp
+++ b/quadratic_root.cpp
@@ -1,11 +1,10 @@
-#include <cmath>        // for std::abs, sqrt
+#include <cmath>        // for fabs, sqrt
 #include <algorithm>    // for std::max, std::min
 #include <stdexcept>    // for std::range_error, std::logic_error
 #include "constants.h"  // for eps_zero
 #include "quadratic_root.h"
 
 using calculation_constants::eps_zero;
-using std::abs;
 using std::logic_error;
 using std::max;
 using std::min;
@@ -67,7 +66,7 @@ double quadratic_root(
     double c,
     quadratic_root_type root_type)
 {
-    if (abs(a) < eps_zero) {
+    if (fabs(a) < eps_zero) {
         return -c / b;
     } else {
         double const root_term = b * b - 4 * a * c;

--- a/state_map.h
+++ b/state_map.h
@@ -95,7 +95,5 @@ state_map state_map_from_names(name_list_type names)
     return m;
 }
 
-state_map abs(state_map x);
-
 #endif
 


### PR DESCRIPTION
While working on PR https://github.com/biocro/biocro/pull/65, I checked for other improper use of `abs` and found two issues in the framework code. One was in `quadratic_root`, where `std::abs` was used in a place that should have used `fabs`. The other was a weird function declaration in `state_map.h` that was not defined anywhere. You can find it in the Doxygen documentation here: https://biocro.github.io/BioCro-documentation/latest/doxygen/doxygen_docs_complete/state__map_8h.html#a2ffa14ffb8d0754a8bece80bb8a68481