### PR TITLE
Get rid of deprecation warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,12 @@ Subsequent commits will then include a new "Unreleased" section in preparation
 for the next release.
 -->
 
+# Unreleased
+
+- Added pragmas to two C++ source code files to suppress warnings
+  about deprecated declarations in the Boost library code when C++17
+  is used for compilation.
+
 # BioCro C++ Framework VERSION 1.1.3
 
 - Replaced `fabs` by `std::abs` in `quadratic_root.cpp` and

--- a/ode_solver.h
+++ b/ode_solver.h
@@ -2,7 +2,12 @@
 #define ODE_SOLVER_H
 
 #include <vector>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <boost/numeric/odeint.hpp>  // For use with ODEINT
+#pragma GCC diagnostic pop
+
 #include "state_map.h"
 #include "dynamical_system.h"
 

--- a/ode_solver_library/boost_ode_solvers.h
+++ b/ode_solver_library/boost_ode_solvers.h
@@ -1,7 +1,11 @@
 #ifndef BOOST_ODE_SOLVERS_H
 #define BOOST_ODE_SOLVERS_H
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <boost/numeric/ublas/vector.hpp>
+#pragma GCC diagnostic pop
+
 #include "../ode_solver.h"
 #include "../dynamical_system_caller.h"
 #include "../state_map.h"  // for state_vector_map


### PR DESCRIPTION
This PR adds pragmas to two C++ source code files to suppress warnings about deprecated declarations in the Boost library code when C++17 is used for compilation.  This will allow use to remove the C++11 SystemRequirement in client R packages.
