### PR TITLE
expose dynamical_system's module names

### DIFF
--- a/R_helper_functions.cpp
+++ b/R_helper_functions.cpp
@@ -85,6 +85,17 @@ string_vector make_vector(SEXP const& r_string_vector)
     return v;
 }
 
+std::vector<double> state_vector_from_r_vector(SEXP const& r_vector)
+{
+    std::vector<double> v;
+    size_t n = Rf_length(r_vector);
+    v.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        v.emplace_back(REAL(r_vector)[i]);
+    }
+    return v;
+}
+
 /**
  *  @brief Creates a std::vector of pointers to module_creator objects from
  *  an R vector of R external pointer objects
@@ -262,6 +273,18 @@ SEXP r_logical_from_boolean(bool b)
     *LOGICAL(logical_output) = b;
     UNPROTECT(1);
     return logical_output;
+}
+
+SEXP r_vector_from_state_vector(std::vector<double> const& state_vector)
+{
+    const size_t dim = state_vector.size();
+    SEXP r_vector = PROTECT(Rf_allocVector(REALSXP, dim));
+    for (size_t i = 0; i < dim; ++i) {
+        REAL(r_vector)
+        [i] = state_vector[i];
+    }
+    UNPROTECT(1);
+    return r_vector;
 }
 
 void output_map(state_map const& m)

--- a/R_helper_functions.h
+++ b/R_helper_functions.h
@@ -14,6 +14,8 @@ string_vector make_vector(SEXP const& r_string_vector);
 
 mc_vector mc_vector_from_list(SEXP const& list);
 
+std::vector<double> state_vector_from_r_vector(SEXP const& r_vector);
+
 SEXP list_from_map(state_map const& m);
 
 SEXP list_from_map(state_vector_map const& m);
@@ -33,6 +35,8 @@ SEXP vector_from_map(state_map const& m);
 SEXP r_string_vector_from_vector(string_vector const& v);
 
 SEXP r_logical_from_boolean(bool b);
+
+SEXP r_vector_from_state_vector(std::vector<double> const& state_vector);
 
 void output_map(state_map const& m);
 

--- a/dynamical_system.cpp
+++ b/dynamical_system.cpp
@@ -199,3 +199,25 @@ string_vector dynamical_system::get_output_quantity_names() const
         vector<state_map>{initial_values, at(drivers, 0)},
         direct_mcs);
 }
+
+string_vector dynamical_system::get_direct_module_names() const
+{
+    string_vector out;
+    out.reserve(
+        direct_modules.size());
+    for (auto& module : direct_mcs) {
+        out.push_back(module->get_name());
+    }
+    return out;
+}
+
+string_vector dynamical_system::get_differential_module_names() const
+{
+    string_vector out;
+    out.reserve(
+        differential_modules.size());
+    for (auto& module : differential_mcs) {
+        out.push_back(module->get_name());
+    }
+    return out;
+}

--- a/dynamical_system.h
+++ b/dynamical_system.h
@@ -177,6 +177,8 @@ class dynamical_system
     vector<const double*> get_quantity_access_ptrs(string_vector quantity_names) const;
     string_vector get_differential_quantity_names() const { return keys(initial_values); }
     string_vector get_output_quantity_names() const;
+    string_vector get_direct_module_names() const;
+    string_vector get_differential_module_names() const;
 
     // For generating reports to the user
     int get_ncalls() const { return ncalls; }


### PR DESCRIPTION
Added API methods to `dynamical_system`. I am doing a pull request because I can't publish branches on `framework` and I have a branch on biocro/biocro that doesn't compile unless these methods are added.